### PR TITLE
Added support Symfony HttpKernel 6.x

### DIFF
--- a/src/MetricBundle/Controller/HttpFoundationResponder.php
+++ b/src/MetricBundle/Controller/HttpFoundationResponder.php
@@ -39,7 +39,7 @@ final class HttpFoundationResponder
                 $response->getHeaders()
             );
         } catch (\Exception $exception) {
-            throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR, null, $exception);
+            throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR, '', $exception);
         }
 
         $symfonyResponse->setPrivate();

--- a/tests/MetricBundle/Controller/HttpFoundationResponderTest.php
+++ b/tests/MetricBundle/Controller/HttpFoundationResponderTest.php
@@ -2,6 +2,7 @@
 
 namespace Lamoda\Metric\MetricBundle\Tests\Controller;
 
+use Exception;
 use Lamoda\Metric\Collector\MetricCollectorInterface;
 use Lamoda\Metric\Common\Metric;
 use Lamoda\Metric\Common\Source\IterableMetricSource;
@@ -9,13 +10,15 @@ use Lamoda\Metric\MetricBundle\Controller\HttpFoundationResponder;
 use Lamoda\Metric\Responder\PsrResponder;
 use Lamoda\Metric\Responder\ResponseFactory\TelegrafJsonResponseFactory;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
  * @covers \Lamoda\Metric\MetricBundle\Controller\HttpFoundationResponder
  */
 final class HttpFoundationResponderTest extends TestCase
 {
-    public function testControllerProducesJsonResult()
+    public function testControllerProducesJsonResult(): void
     {
         $m1 = new Metric('m1', 1.1);
         $m2 = new Metric('m2', 2);
@@ -40,5 +43,20 @@ JSON;
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
         $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
+    }
+
+    public function testControllerCorrectHandleException(): void
+    {
+        $exception = new Exception('Test exception');
+        $expectedExceptionObject = new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR, '', $exception);
+
+        $collector = $this->createMock(MetricCollectorInterface::class);
+        $collector->method('collect')->willThrowException($exception);
+
+        $controller = new HttpFoundationResponder(new PsrResponder($collector, new TelegrafJsonResponseFactory()));
+
+        $this->expectExceptionObject($expectedExceptionObject);
+
+        $controller->createResponse();
     }
 }


### PR DESCRIPTION
- Replaced the null-parameter with an empty string to match the class constructor signature
- Added a test to check for correct exception handling